### PR TITLE
主にスペーシングの修正と既定とデフォルトの混同を正す

### DIFF
--- a/ExplorerPatcher/GUI.c
+++ b/ExplorerPatcher/GUI.c
@@ -2198,7 +2198,7 @@ static BOOL GUI_Build(HDC hDC, HWND hwnd, POINT pt)
                             {
                                 if (MessageBoxW(
                                     hwnd,
-                                    L"天気予報ウィジェットのローカルデータを永久にクリアしてもよろしいですか？\n\n"
+                                    L"天気予報ウィジェットのローカル データを永久にクリアしてもよろしいですか?\n\n"
                                     L"これは内部コンポーネントをデフォルトの状態にリセットしますが、あなたの設定は保持されます。 "
                                     L"これにより、ウィジェットがデータを正しくロードしない、 "
                                     L"または、レイアウトの問題があるなどの問題が解決されるかもしれません。",
@@ -4018,7 +4018,7 @@ __declspec(dllexport) int ZZGUI(HWND hWnd, HINSTANCE hInstance, LPSTR lpszCmdLin
         }
     }
 
-    wprintf(L"Windows %d で動作しており、 OS Buildは %d.%d.%d.%dです。\n", IsWindows11() ? 11 : 10, global_rovi.dwMajorVersion, global_rovi.dwMinorVersion, global_rovi.dwBuildNumber, global_ubr);
+    wprintf(L"Windows %d で動作しており、OS Build は %d.%d.%d.%d です。\n", IsWindows11() ? 11 : 10, global_rovi.dwMajorVersion, global_rovi.dwMinorVersion, global_rovi.dwBuildNumber, global_ubr);
 
     locale = GetUserDefaultUILanguage();
     dwSize = LOCALE_NAME_MAX_LENGTH;

--- a/ExplorerPatcher/settings.reg
+++ b/ExplorerPatcher/settings.reg
@@ -7,25 +7,25 @@
 ;T タスク バー
 [HKEY_CURRENT_USER\Software\ExplorerPatcher]
 ;z 2 タスク バーのスタイル *
-;x 0 Windows 11 (既定)
+;x 0 Windows 11 (デフォルト)
 ;x 1 Windows 10
 "OldTaskbar"=dword:00000001
-;y 設定アプリでその他のタスク バーオプションを開く🡕
+;y 設定アプリでその他のタスク バー オプションを開く🡕
 ;ms-settings:taskbar
 ;y 通知領域のアイコンをカスタマイズする 🡕
 ;shell:::{05d7b0f4-2121-4eff-bf6b-ed3f69b894d9}
-;y 通知領域のシステムアイコンをカスタマイズする 🡕
+;y 通知領域のシステム アイコンをカスタマイズする 🡕
 ;shell:::{05d7b0f4-2121-4eff-bf6b-ed3f69b894d9}\SystemIcons
 ;s Taskbar_LocationSection !(IsWindows11Version22H2OrHigher&&!IsOldTaskbar)
 [HKEY_CURRENT_USER\Software\ExplorerPatcher]
 ;c 4 画面上のプライマリ タスク バーの位置 *
-;x 3 下 (既定)
+;x 3 下 (デフォルト)
 ;x 1 上
 ;x 0 左
 ;x 2 右
 ;"Virtualized_{D17F1E1A-5919-4427-8F89-A1A8503CA3EB}_TaskbarPosition"=dword:00000003
 ;c 4 画面上のセカンダリ タスク バーの位置
-;x 3 下 (既定)
+;x 3 下 (デフォルト)
 ;x 1 上
 ;x 0 左
 ;x 2 右
@@ -34,7 +34,7 @@
 ;s Taskbar_CortanaButtonSection !IsWindows11Version22H2OrHigher
 [HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced]
 ;c 3 他のボタンの処理
-;x 0 隠す (既定)
+;x 0 隠す (デフォルト)
 ;x 2 Cortana を開く
 ;x 1 ウィジェットを開く
 "TaskbarDa"=dword:00000000
@@ -57,51 +57,51 @@
 ;"Virtualized_{D17F1E1A-5919-4427-8F89-A1A8503CA3EB}_AutoHideTaskbar"=dword:00000000
 ;s Taskbar_Windows10Section IsOldTaskbar
 [HKEY_CURRENT_USER\Software\ExplorerPatcher]
-;c 2 スタートボタンのスタイル *
-;x 0 Windows 10 (既定)
+;c 2 スタート ボタンのスタイル *
+;x 0 Windows 10 (デフォルト)
 ;x 1 Windows 11
 "OrbStyle"=dword:00000000
 ;c 5 プライマリ タスク バーの配置
-;x 0 画面端 (既定)
+;x 0 画面端 (デフォルト)
 ;x 1 中央
 ;x 5 中央、フルスクリーン時画面端
-;x 3 スタートボタンを中心に
-;x 7 スタートボタンを中心に、フルスクリーン時は画面端に配置
+;x 3 スタート ボタンを中心に
+;x 7 スタート ボタンを中心に、フルスクリーン時は画面端に配置
 "OldTaskbarAl"=dword:00000000
 ;c 5 セカンダリ タスク バーの配置
-;x 0 画面端 (既定)
+;x 0 画面端 (デフォルト)
 ;x 1 中央
 ;x 5 中央、フルスクリーン時画面端
-;x 3 スタートボタンを中心に
-;x 7 スタートボタンを中心に、フルスクリーン時は画面端に配置
+;x 3 スタート ボタンを中心に
+;x 7 スタート ボタンを中心に、フルスクリーン時は画面端に配置
 "MMOldTaskbarAl"=dword:00000000
 ;c 3 プライマリ タスク バーのアイコンを結合
 ;x 0 常に結合する
 ;x 1 タスク バーがいっぱいのときに結合
-;x 2 結合しない (既定)
+;x 2 結合しない (デフォルト)
 "TaskbarGlomLevel"=dword:00000002
 ;c 3 セカンダリ タスク バーのアイコン結合
 ;x 0 常に結合する
 ;x 1 タスク バーがいっぱいのときに結合
-;x 2 結合しない (既定)
+;x 2 結合しない (デフォルト)
 "MMTaskbarGlomLevel"=dword:00000002
 [HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced]
-;c 2 タスク バーのアイコンサイズ
+;c 2 タスク バーのアイコン サイズ
 ;x 1 小さい
-;x 0 大きい (既定)
+;x 0 大きい (デフォルト)
 "TaskbarSmallIcons"=dword:00000000
 ;e 
 ;e 
 ;g Taskbar_Windows10Section
 
 
-;T システムトレイ
+;T システム トレイ
 [HKEY_CURRENT_USER\Software\ExplorerPatcher]
-;b タスク バーとトレイのポップアップメニューのスキン
+;b タスク バーとトレイのポップアップ メニューのスキン
 "SkinMenus"=dword:00000001
-;b センタートレイのアイコンのポップアップメニュー
+;b センター トレイのアイコンのポップアップ メニュー
 "CenterMenus"=dword:00000001
-;b トレイアイコンのポップアップメニューのフライアウト動作
+;b トレイ アイコンのポップアップ メニューのフライアウト動作
 "FlyoutMenus"=dword:00000001
 [HKEY_CURRENT_USER\Software\Microsoft\TabletTip\1.7]
 ;b タッチ キーボード ボタンを表示する *
@@ -112,12 +112,12 @@
 "ShowSecondsInSystemClock"=dword:00000000
 ;g SystemTray_Section98
 [HKEY_CURRENT_USER\Software\ExplorerPatcher]
-;i コントロールセンター ボタンを表示する *
+;i コントロール センター ボタンを表示する *
 "HideControlCenterButton"=dword:00000000
 ;s SystemTray_Section109 IsOldTaskbar
 [HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced]
 ;c 3 デスクトップ ボタンを表示する
-;x 1 有効にする (既定)
+;x 1 有効にする (デフォルト)
 ;x 0 無効にする
 ;x 2 隠す
 "TaskbarSD"=dword:00000001
@@ -130,47 +130,47 @@
 ;s SystemTray_Windows10Section IsOldTaskbar
 [HKEY_CURRENT_USER\Software\ExplorerPatcher]
 ;p 2
-;b システムトレイアイコンにWindows 11 のスタイルを適用 *
+;b システム トレイ アイコンに Windows 11 のスタイルを適用 *
 "SkinIcons"=dword:00000001
 [HKEY_CURRENT_USER\Software\ExplorerPatcher]
-;a ネットワークアイコンを右クリックし、「ネットワークとインターネットの設定を開く」
+;a ネットワーク アイコンを右クリックし、「ネットワークとインターネットの設定を開く」
 ;c 3 を選択した時開くウィンドウ
-;x 0 設定アプリのネットワーク設定 (既定)
-;x 1 コントロールパネルのネットワークと共有
-;x 2 コントロールパネルのネットワーク接続
+;x 0 設定アプリのネットワーク設定 (デフォルト)
+;x 1 コントロール パネルのネットワークと共有
+;x 2 コントロール パネルのネットワーク接続
 "ReplaceNetwork"=dword:00000000
 ;q
-;t Windows 10 のシステムトレイ上のアイコンをクリック時:
+;t Windows 10 のシステム トレイ上のアイコンをクリック時:
 [HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Control Panel\Settings\Network]
 ;c 7 ネットワーク
-;x 6 コントロールセンター
-;x 5 Windows 11 のWi-Fiフライアウト
-;x 0 Windows 10 のフライアウト (既定)
+;x 6 コントロール センター
+;x 5 Windows 11 の Wi-Fi フライアウト
+;x 0 Windows 10 のフライアウト (デフォルト)
 ;x 2 Windows 8 のフライアウト
 ;x 1 設定アプリのネットワーク設定
-;x 3 コントロールパネルのネットワークと共有
-;x 4 コントロールパネルのネットワーク接続
+;x 3 コントロール パネルのネットワークと共有
+;x 4 コントロール パネルのネットワーク接続
 "ReplaceVan"=dword:00000000
 [HKEY_CURRENT_USER\Software\Microsoft\Windows NT\CurrentVersion\MTCUVC]
 ;c 2 サウンド
-;x 1 Windows 10 のフライアウト (既定)
+;x 1 Windows 10 のフライアウト (デフォルト)
 ;x 0 Windows 7 のフライアウト
 "EnableMtcUvc"=dword:00000001
 [HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\ImmersiveShell]
 ;c 3 時計
 ;x 2 Windows 11 のフライアウト
-;x 0 Windows 10 のフライアウト (既定)
+;x 0 Windows 10 のフライアウト (デフォルト)
 ;x 1 Windows 7
 "UseWin32TrayClockExperience"=dword:00000000
 [HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\ImmersiveShell]
 ;c 2 バッテリー
-;x 0 Windows 10 のフライアウト (既定)
+;x 0 Windows 10 のフライアウト (デフォルト)
 ;x 1 Windows 7
 "UseWin32BatteryFlyout"=dword:00000000
 ;s SystemTray_LanguageSwitcherAfter22H2 IsWindows11Version22H2OrHigher
 [HKEY_CURRENT_USER\Software\ExplorerPatcher]
-;c 4 キーボードレイアウト(IME) の切り替え *
-;x 0 Windows 11 のフライアウト (既定)
+;c 4 キーボード レイアウト (IME) の切り替え *
+;x 0 Windows 11 のフライアウト (デフォルト)
 ;x 7 Windows 10 のフライアウト
 ;x 1 Windows 10 のフライアウト (言語設定の項目あり / アニメーションなし)
 ;x 4 Windows 10 のフライアウト (言語設定の項目なし / アニメーションなし)
@@ -180,8 +180,8 @@
 
 
 
-;T ファイルエクスプローラー
-;e (**) の付いた設定が"ファイルを開く"または"ファイルを保存する"ダイアログで機能するには、
+;T ファイル エクスプローラー
+;e (**) の付いた設定が "ファイルを開く" または "ファイルを保存する" ダイアログで機能するには、
 ;e 以下のオプションを利用してこのプログラムをシェル拡張として登録します。
 ;y 詳しく見る 🡕
 ;https://github.com/valinet/ExplorerPatcher/wiki/Using-ExplorerPatcher-as-shell-extension
@@ -196,15 +196,15 @@
 ;b 常にレガシーなファイル転送ダイアログを使用する
 "LegacyFileTransferDialog"=dword:00000000
 [HKEY_CURRENT_USER\Software\ExplorerPatcher]
-;b クラシックなドライブグループを使用する
+;b クラシックなドライブ グループを使用する
 "UseClassicDriveGrouping"=dword:00000000
 [HKEY_CURRENT_USER\Software\ExplorerPatcher]
-;c 3 コントロールインターフェース *
-;x 0 Windows 11 のコマンド バー (既定)
+;c 3 コントロール インターフェイス *
+;x 0 Windows 11 のコマンド バー (デフォルト)
 ;x 1 Windows 10 のリボン UI
 ;x 2 Windows 7 のコマンド バー
 ;"Virtualized_{D17F1E1A-5919-4427-8F89-A1A8503CA3EB}_FileExplorerCommandUI"=dword:00000000
-;t 以下の設定は、新しく作成されたファイルエクスプローラーのウィンドウに適用されます:
+;t 以下の設定は、新しく作成されたファイル エクスプローラーのウィンドウに適用されます:
 [HKEY_CURRENT_USER\Software\ExplorerPatcher]
 ;i Windows 10 のコンテキストメニューの表示時、没入型メニューを使用する **
 "DisableImmersiveContextMenu"=dword:00000000
@@ -215,7 +215,7 @@
 ;b モダンな検索バーを無効にする
 ;"Virtualized_{D17F1E1A-5919-4427-8F89-A1A8503CA3EB}_DisableModernSearchBar"=dword:00000000
 [HKEY_CURRENT_USER\Software\ExplorerPatcher]
-;b アドレスバーの高さを下げる **
+;b アドレス バーの高さを下げる **
 "ShrinkExplorerAddressBar"=dword:00000000
 [HKEY_CURRENT_USER\Software\ExplorerPatcher]
 ;b 検索バーを完全に隠す **
@@ -223,32 +223,32 @@
 ;s Explorer_TitlebarSection !IsWindows11Version22H2OrHigher
 [HKEY_CURRENT_USER\Software\ExplorerPatcher]
 ;c 4 タイトル バー
-;x 0 アイコンとタイトルを表示 (既定)
+;x 0 アイコンとタイトルを表示 (デフォルト)
 ;x 1 タイトルを隠してアイコンを表示
 ;x 2 アイコンを隠してタイトルを表示
 ;x 3 アイコンとタイトルを隠す
 "HideIconAndTitleInExplorer"=dword:00000000
 [HKEY_CURRENT_USER\Software\ExplorerPatcher]
 ;c 3 マイカ効果(透過ぼかし)を適用する範囲
-;x 0 ファイルエクスプローラーに任せる (既定)
+;x 0 ファイル エクスプローラーに任せる (デフォルト)
 ;x 1 タイトル バー、コマンド バー、ナビゲーション バーに適用
 ;x 2 使用しない
 "MicaEffectOnTitlebar"=dword:00000000
 ;g Explorer_TitlebarSection
 
 
-;T スタートメニュー
+;T スタート メニュー
 [HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced]
-;z 2 スタートメニューのスタイル
-;x 0 Windows 11 (既定)
+;z 2 スタート メニューのスタイル
+;x 0 Windows 11 (デフォルト)
 ;x 1 Windows 10
 "Start_ShowClassicMode"=dword:00000000
-;y 設定アプリのその他のスタートメニューオプション 🡕
+;y 設定アプリのその他のスタート メニュー オプション 🡕
 ;ms-settings:personalization-start
 [HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced]
 ;c 2 画面上の位置
 ;x 0 画面端
-;x 1 中央 (既定)
+;x 1 中央 (デフォルト)
 "TaskbarAl"=dword:00000001
 [HKEY_CURRENT_USER\Software\ExplorerPatcher]
 ;c 22 よく使うアプリの最大表示数
@@ -258,7 +258,7 @@
 ;x 3 3
 ;x 4 4
 ;x 5 5
-;x 6 6 (既定)
+;x 6 6 (デフォルト)
 ;x 7 7
 ;x 8 8
 ;x 9 9
@@ -276,9 +276,9 @@
 ;x 99999 無制限
 ;"Virtualized_{D17F1E1A-5919-4427-8F89-A1A8503CA3EB}_Start_MaximumFrequentApps"=dword:00000006
 [HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Explorer\StartPage]
-;a マルチ ディスプレイの場合、キーボードを使用すると設定されたディスプレイで
+;a マルチディスプレイの場合、キーボードを使用すると設定されたディスプレイで
 ;c 10 スタートが表示されます
-;x 1 プライマリ ディスプレイ (既定)
+;x 1 プライマリ ディスプレイ (デフォルト)
 ;x 0 カーソルがあるディスプレイ
 ;x 2 ディスプレイ #2
 ;x 3 ディスプレイ #3
@@ -291,10 +291,10 @@
 "MonitorOverride"=dword:00000001
 ;s StartMenu_Windows11 !IsWindows10StartMenu
 [HKEY_CURRENT_USER\Software\ExplorerPatcher]
-;b "おすすめ"の項目を無効にする
+;b "おすすめ" の項目を無効にする
 ;"Virtualized_{D17F1E1A-5919-4427-8F89-A1A8503CA3EB}_StartDocked_DisableRecommendedSection"=dword:00000000
 [HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Explorer\StartPage]
-;b "すべてのアプリ"を展開した状態でスタートを開く
+;b "すべてのアプリ" を展開した状態でスタートを開く
 "MakeAllAppsDefault"=dword:00000000
 ;g StartMenu_Windows11
 ;s StartMenu_Windows10 IsWindows10StartMenu
@@ -302,31 +302,31 @@
 ;b その他のタイルを表示する
 ;"Virtualized_{D17F1E1A-5919-4427-8F89-A1A8503CA3EB}_StartUI_ShowMoreTiles"=dword:00000000
 ;c 3 コーナーの設定
-;x 1 丸みを帯びた角、フローティングメニュー
-;x 2 丸みを帯びた角、ドッキングメニュー
+;x 1 丸みを帯びた角、フローティング メニュー
+;x 2 丸みを帯びた角、ドッキング メニュー
 ;x 0 丸みなし
 ;"Virtualized_{D17F1E1A-5919-4427-8F89-A1A8503CA3EB}_StartUI_EnableRoundedCorners"=dword:00000000
 [HKEY_CURRENT_USER\Software\ExplorerPatcher]
 ;c 3 表示方法
-;x 0 既定
-;x 1 スタートメニュー
-;x 2 フルスクリーンのスタートメニュー
+;x 0 デフォルト
+;x 1 スタート メニュー
+;x 2 フルスクリーンのスタート メニュー
 ;"Virtualized_{D17F1E1A-5919-4427-8F89-A1A8503CA3EB}_ForceStartSize"=dword:00000000
 ;c 3 アプリ一覧
 ;x 0 表示
 ;x 3 隠す
-;x 1 無効にする
+;x 1 無効にする 
 ;"Virtualized_{D17F1E1A-5919-4427-8F89-A1A8503CA3EB}_NoStartMenuMorePrograms"=dword:00000000
-;u ファイルエクスプローラーからWindows 10 のスタートメニューにタイルをピン留めする
+;u ファイル エクスプローラーから Windows 10 のスタート メニューにタイルをピン留めする
 ;pin_tiles
 ;g StartMenu_Windows10
 
 
 
-;T ウインドウの切り替え
+;T ウィンドウの切り替え
 [HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Explorer]
 ;z 4 ウィンドウの切り替え (Alt+Tab) のスタイルを変更 *
-;x 0 Windows 11 (既定)
+;x 0 Windows 11 (デフォルト)
 ;x 3 Windows 10
 ;x 1 Windows NT
 ;x 2 Simple Window Switcher
@@ -339,12 +339,12 @@
 "PrimaryOnly"=dword:00000000
 ;b 現在のディスプレイで表示されているウィンドウのみを表示する
 "PerMonitor"=dword:00000000
-;b 直近のウィンドウのみ表示 (アプリケーションスイッチャーごと)
+;b 直近のウィンドウのみ表示 (アプリケーション スイッチャーごと)
 "SwitcherIsPerApplication"=dword:00000000
 ;b %PLACEHOLDER_0001%
 "NoPerApplicationList"=dword:00000000
 ;c 3 テーマ
-;x 0 既定
+;x 0 デフォルト
 ;x 1 アクリル
 ;x 2 マイカ (常に不透明)
 "Theme"=dword:00000000
@@ -353,7 +353,7 @@
 ;x 100 不透明
 ;x 98 98 %
 ;x 96 96 %
-;x 95 95 % (既定)
+;x 95 95 % (デフォルト)
 ;x 94 94 %
 ;x 92 92 %
 ;x 90 90 %
@@ -372,13 +372,13 @@
 "Grid_backgroundPercent"=dword:0000005F
 [HKEY_CURRENT_USER\Software\ExplorerPatcher\sws]
 ;c 3 配色
-;x 0 システムの設定に従う (既定)
+;x 0 システムの設定に従う (デフォルト)
 ;x 1 ライト
 ;x 2 ダーク
 "ColorScheme"=dword:00000000
 [HKEY_CURRENT_USER\Software\ExplorerPatcher\sws]
 ;c 3 コーナーの設定
-;x 2 丸める (既定)
+;x 2 丸める (デフォルト)
 ;x 3 少しだけ丸める
 ;x 1 丸みなし
 "CornerPreference"=dword:00000002
@@ -394,7 +394,7 @@
 ;x 260 260 pt
 ;x 250 250 pt
 ;x 240 240 pt
-;x 230 230 pt (既定)
+;x 230 230 pt (デフォルト)
 ;x 220 220 pt
 ;x 210 210 pt
 ;x 200 200 pt
@@ -410,7 +410,7 @@
 ;x 95 95 %
 ;x 90 90 %
 ;x 85 85 %
-;x 80 80 % (既定)
+;x 80 80 % (デフォルト)
 ;x 75 75 %
 ;x 70 70 %
 ;x 65 65 %
@@ -422,7 +422,7 @@
 ;x 95 95 %
 ;x 90 90 %
 ;x 85 85 %
-;x 80 80 % (既定)
+;x 80 80 % (デフォルト)
 ;x 75 75 %
 ;x 70 70 %
 ;x 65 65 %
@@ -436,7 +436,7 @@
 ;x 35 30 pt
 ;x 30 30 pt
 ;x 25 25 pt
-;x 20 20 pt (既定)
+;x 20 20 pt (デフォルト)
 ;x 15 15 pt
 ;x 10 10 pt
 ;x 5 5 pt
@@ -447,7 +447,7 @@
 ;x 25 25 ミリ秒
 ;x 50 50 ミリ秒
 ;x 75 75 ミリ秒
-;x 100 100 ミリ秒 (既定)
+;x 100 100 ミリ秒 (デフォルト)
 ;x 125 125 ミリ秒
 ;x 150 150 ミリ秒
 ;x 200 200 ミリ秒
@@ -455,8 +455,8 @@
 ;x 400 400 ミリ秒
 ;x 500 500 ミリ秒
 "ShowDelay"=dword:00000064
-;c 3 ホイールスクロールで選択項目を変更
-;x 0 しない (既定)
+;c 3 ホイール スクロールで選択項目を変更
+;x 0 しない (デフォルト)
 ;x 1 カーソルが選択項目上にある場合
 ;x 2 常に
 "ScrollWheelBehavior"=dword:00000000
@@ -474,63 +474,63 @@
 ;"Virtualized_{D17F1E1A-5919-4427-8F89-A1A8503CA3EB}_PeopleBand"=dword:00000000
 ;s Weather_Section1 IsWeatherEnabled
 ;w 場所
-;都市または郵便番号を検索します。プログラムはGoogleで"/*あなたが入力した場所*/の天気"を検索します。規定値(現在地)は空白のままにしておきます。
-;現在地 (既定)
+;都市または郵便番号を検索します。プログラムは Google で "/*あなたが入力した場所*/の天気" を検索します。デフォルト値 (現在地) は空白のままにしておきます。
+;現在地 (デフォルト)
 "WeatherLocation"=""
 ;c 5 レイアウト
-;x 0 アイコンと概要 (既定)
+;x 0 アイコンと概要 (デフォルト)
 ;x 3 アイコンと温度
 ;x 1 アイコンのみ
 ;x 4 温度のみ
 ;x 5 温度と概要
 "WeatherViewMode"=dword:00000000
 ;c 3 ウィジェットのサイズ
-;x 0 自動 (内容に合わせて) (既定)
+;x 0 自動 (内容に合わせて) (デフォルト)
 ;x 2 自動 (内容に合わせて) しきい値あり
 ;x 1 固定
 "WeatherFixedSize"=dword:00000000
 ;c 2 ウィジェットの位置
-;x 0 右 / 下部 (既定)
+;x 0 右 / 下部 (デフォルト)
 ;x 1 左 / 上部
 "WeatherToLeft"=dword:00000000
 ;c 7 更新頻度
 ;x 60 毎分
 ;x 300 5 分ごと
 ;x 900 15 分ごと
-;x 1200 20 分ごと (既定)
+;x 1200 20 分ごと (デフォルト)
 ;x 1800 30 分ごと
 ;x 3600 毎時間おき
 ;x 7200 数時間おき
 "WeatherContentUpdateMode"=dword:000004B0
 ;c 2 温度単位
-;x 0 摂氏 (既定)
+;x 0 摂氏 (デフォルト)
 ;x 1 華氏
 "WeatherTemperatureUnit"=dword:00000000
 ;;;c 2 位置情報の精度
-;;;x 0 一般的 (IPアドレスに基づく) (既定)
+;;;x 0 一般的 (IP アドレスに基づく) (デフォルト)
 ;;;x 1 精密 (位置情報を使用します)
 ;;"WeatherLocationType"=dword:00000000
 ;w 言語
-;天気データを表示させたい言語のショートコードを入力します。("en", "ro", "de", "fr "など) デフォルト値 (Windows の言語)は空白にしてください。
-;システムの言語 (既定)
+;天気データを表示させたい言語のショート コードを入力します。("en", "ro", "de", "fr" など) デフォルト値 (Windows の言語) は空白にしてください。
+;システムの言語 (デフォルト)
 "WeatherLanguage"=""
 ;c 3 配色
-;x 0 システムの設定に従う (既定)
+;x 0 システムの設定に従う (デフォルト)
 ;x 1 ライト
 ;x 2 ダーク
 "WeatherTheme"=dword:00000000
 ;c 3 コーナーの設定
-;x 2 丸める (既定)
+;x 2 丸める (デフォルト)
 ;x 3 少しだけ丸める
 ;x 1 丸みなし
 "WeatherWindowCornerPreference"=dword:00000002
-;c 2 アイコンパック
-;x 0 Microsoft (既定)
+;c 2 アイコン パック
+;x 0 Microsoft (デフォルト)
 ;x 1 Google
 "WeatherIconPack"=dword:00000000
 ;c 2 ウィジェットの内容を表示する
-;x 0 1 行で表示 (既定)
-;x 1 可能であれば2 行で表示
+;x 0 1 行で表示 (デフォルト)
+;x 1 可能であれば 2 行で表示
 "WeatherContentsMode"=dword:00000000
 ;c 17 拡大率
 ;x 25 25 %
@@ -540,7 +540,7 @@
 ;x 75 75 %
 ;x 80 80 %
 ;x 90 90 %
-;x 0 100 % (既定)
+;x 0 100 % (デフォルト)
 ;x 110 110 %
 ;x 125 125 %
 ;x 150 150 %
@@ -559,7 +559,7 @@
 ;t %WEATHERLASTUPDATETEXT%
 ;u 天気予報を更新する
 ;update_weather
-;u 天気予報ウィジェットのローカルデータをクリアする
+;u 天気予報ウィジェットのローカル データをクリアする
 ;clear_data_weather
 ;g Weather_Section2
 ;g Weather_Windows10
@@ -583,7 +583,7 @@
 ;x 1008 すべての項目
 "SpotlightDesktopMenuMask"=dword:00000000
 ;c 11 更新頻度
-;x 0 Windows に最適なスケジュールを決定させる (既定)
+;x 0 Windows に最適なスケジュールを決定させる (デフォルト)
 ;x 60 毎分
 ;x 300 5 分毎
 ;x 900 15 分毎
@@ -617,41 +617,41 @@
 [HKEY_CURRENT_USER\Software\ExplorerPatcher]
 ;b このウィンドウで最後に使用したセクションを記憶する
 "LastSectionInProperties"=dword:00000000
-;b Win+Cを押した時、Microsoft Teams の代わりに時計のフライアウトを開く *
+;b Win+C を押した時、Microsoft Teams の代わりに時計のフライアウトを開く *
 "ClockFlyoutOnWinC"=dword:00000000
-;b タスク バーのツール バーの間にセパレーターを表示する *
+;b タスク バーのツールバーの間にセパレーターを表示する *
 "ToolbarSeparators"=dword:00000000
 [HKEY_CURRENT_USER\Software\ExplorerPatcher]
 ;b Win+X メニューにプログラムの設定のショートカットを追加する
 "PropertiesInWinX"=dword:00000000
-;b Win+X メニューのプログラム設定項目からショートカットキーを削除する
+;b Win+X メニューのプログラム設定項目からショートカット キーを削除する
 "NoMenuAccelerator"=dword:00000000
-;b Office ホットキー (Ctrl+Alt+Shift+Windows キーの組み合わせ)を無効化する *
+;b Office ホットキー (Ctrl+Alt+Shift+Windows キーの組み合わせ) を無効化する *
 "DisableOfficeHotkeys"=dword:00000000
-;b Win+F (フィードバック Hub)ホットキーを無効化する *
+;b Win+F (フィードバック Hub) ホットキーを無効化する *
 "DisableWinFHotkey"=dword:00000000
-;b アプリケーションウィンドウの角の丸みを無効化する
+;b アプリケーション ウィンドウの角の丸みを無効化する
 ;"Virtualized_{D17F1E1A-5919-4427-8F89-A1A8503CA3EB}_DisableRoundedCorners"=dword:00000000
 [HKEY_CURRENT_USER\Software\ExplorerPatcher]
 ;b ウィンドウをスナップ時の象限を無効にする *
 "DisableAeroSnapQuadrants"=dword:00000000
 ;s Other_SnapAssistStyle !IsWindows11Version22H2OrHigher
 [HKEY_CURRENT_USER\Software\ExplorerPatcher]
-;c 2 スナップアシストのスタイル
-;x 0 Windows 11 (既定)
+;c 2 スナップ アシストのスタイル
+;x 0 Windows 11 (デフォルト)
 ;x 3 Windows 10
 "SnapAssistSettings"=dword:00000000
 ;g Other_SnapAssistStyle
 [HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced]
-;c 6 デスクトップ上のAlt+F4 ダイアログの既定の動作
+;c 6 デスクトップ上の Alt+F4 ダイアログのデフォルトの動作
 ;x 256 ユーザーの切り替え
 ;x 1 サインアウト
 ;x 16 スリープ
 ;x 64 休止状態
-;x 2 シャットダウン (既定)
+;x 2 シャットダウン (デフォルト)
 ;x 4 再起動
 "Start_PowerButtonAction"=dword:00000002
-;t 以下のコントロールパネルのリンクが設定アプリにリダイレクトされないようにします:
+;t 以下のコントロール パネルのリンクが設定アプリにリダイレクトされないようにします:
 [HKEY_CURRENT_USER\Software\ExplorerPatcher]
 ;b システム / このページについて
 "DoNotRedirectSystemToSettingsApp"=dword:00000000
@@ -665,8 +665,8 @@
 
 ;T アップデート
 [HKEY_CURRENT_USER\Software\ExplorerPatcher]
-;z 3 ファイルエクスプローラーの起動時
-;x 1 利用可能なアップデートを通知する (既定)
+;z 3 ファイル エクスプローラーの起動時
+;x 1 利用可能なアップデートを通知する (デフォルト)
 ;x 0 利用可能なアップデートをインストールするためのプロンプトを表示
 ;x 2 アップデートをチェックしない
 "UpdatePolicy"=dword:00000001
@@ -674,18 +674,18 @@
 "UpdatePreferStaging"=dword:00000000
 ;b 古いバージョンでも、サーバー上の最新バージョンを提案する (非推奨)
 "UpdateAllowDowngrades"=dword:00000000
-;t アップデートサーバー:
+;t アップデート サーバー:
 ;w リリース
-;GitHub の releases API に準拠したリソースを提供する URL を指定します。独自のアップデートサーバーを設定する方法については、wiki をご参照ください。
+;GitHub の releases API に準拠したリソースを提供する URL を指定します。独自のアップデート サーバーを設定する方法については、wiki をご参照ください。
 ;github.com/creeper-0910/ExplorerPatcher-jp/releases/latest
 "UpdateURL"=""
 ;w プレリリース
-;GitHub の pre-releases API に準拠したリソースを提供する URL を指定します。独自のアップデートサーバーを設定する方法については、wiki をご参照ください。
+;GitHub の pre-releases API に準拠したリソースを提供する URL を指定します。独自のアップデート サーバーを設定する方法については、wiki をご参照ください。
 ;api.github.com/repos/creeper-0910/ExplorerPatcher-jp/releases?per_page=1
 "UpdateURLStaging"=""
-;y アップデートを確認する
+;y アップデートを確認
 ;;;EP_CHECK_FOR_UPDATES
-;y アップデートを行い、ファイルエクスプローラーを再起動する
+;y アップデートを行い、ファイル エクスプローラーを再起動
 ;;;EP_INSTALL_UPDATES
 ;y 最新リリースの変更点について 🡕
 ;https://github.com/valinet/ExplorerPatcher/blob/master/CHANGELOG.md
@@ -701,7 +701,7 @@
 [HKEY_CURRENT_USER\Software\ExplorerPatcher]
 ;b コンソールを有効にする
 "AllocConsole"=dword:00000000
-;b メモリリークをダンプする(デバッグビルドのみ)
+;b メモリ リークをダンプする (デバッグ ビルドのみ)
 "Memcheck"=dword:00000000
 ;b タスク バーのダブルクリックで自動的に非表示にする (タスク バーが固定されている時のみ)
 "TaskbarAutohideOnDoubleClick"=dword:00000000
@@ -709,24 +709,24 @@
 ;b Windows のビルド情報をデスクトップに表示 *
 "PaintDesktopVersion"=dword:00000000
 [HKEY_CURRENT_USER\Software\ExplorerPatcher]
-;b クラシックテーマを使用した正しいレンダリングのための高度な緩和策を有効にする *
+;b クラシック テーマを使用した正しいレンダリングのための高度な緩和策を有効にする *
 "ClassicThemeMitigations"=dword:00000000
 [-HKEY_CURRENT_USER\Software\Classes\CLSID\{1eeb5b5a-06fb-4732-96b3-975c0194eb39}\InprocServer32]
-;d エクスプローラーのビューでSysListView32 を有効にする *
+;d エクスプローラーのビューで SysListView32 を有効にする *
 @=""
 [HKEY_CURRENT_USER\Software\ExplorerPatcher]
-;b タスク バーのコンテキストメニューを変更しない（例："プロパティ"項目を非表示にする）
+;b タスク バーのコンテキストメニューを変更しない（例: "プロパティ" 項目を非表示にする）
 "NoPropertiesInContextMenu"=dword:00000000
 ;b シンボルのダウンロードを有効化する *
 "EnableSymbolDownload"=dword:00000001
 ;s Advanced_Windows10 IsOldTaskbar
-;b ピン留めされたアイテムはクイック起動として機能します(ピン留めされたアイテムをアクティブなアプリと一緒にしないでください) *
+;b ピン留めされたアイテムはクイック起動として機能します (ピン留めされたアイテムをアクティブなアプリと一緒にしないでください) *
 "PinnedItemsActAsQuickLaunch"=dword:00000000
-;b タスク バーにボタンラベルが表示されている場合、ピン留めされているアイテムの周りの余分な隙間を削除する *
+;b タスク バーにボタン ラベルが表示されている場合、ピン留めされているアイテムの周りの余分な隙間を削除する *
 "RemoveExtraGapAroundPinnedItems"=dword:00000000
 ;g Advanced_Windows10
 ;c 12 ログオン時の遅延時間の補助 *
-;x 0 なし (既定)
+;x 0 なし (デフォルト)
 ;x 300 300 ミリ秒
 ;x 600 600 ミリ秒
 ;x 1000 1 秒
@@ -750,34 +750,34 @@
 ;e Valentin-Gabriel Radu によって設計されました。この非公式日本語版は、creeper-0910 によって作成されています。
 ;e 動作環境: Windows 11
 ;t OS ビルド: %OSVERSIONSTRING%
-;y プロジェクトのGitHub (公式ビルド) (https://github.com/valinet) 🡕
+;y プロジェクトの GitHub (公式ビルド) (https://github.com/valinet) 🡕
 ;https://github.com/valinet
 ;y プロジェクトのGitHub (非公式日本語版ビルド) (https://github.com/creeper-0910/ExplorerPatcher-jp) 🡕
 ;https://github.com/creeper-0910/ExplorerPatcher-jp
 ;q
-;y 公式のWeb サイト (https://www.valinet.ro) 🡕
+;y 公式の Webサイト (https://www.valinet.ro) 🡕
 ;https://www.valinet.ro
 ;y 公式の作者にメールを送る (valentingabrielradu@gmail.com) 🡕
 ;mailto:valentingabrielradu@gmail.com
-;y 公式の作者に寄付をする (PayPal を利用します) 🡕
+;y 公式の作者に寄付をする (PayPal を利用) 🡕
 ;https://www.paypal.com/donate?business=valentingabrielradu%40gmail.com&no_recurring=0&item_name=ExplorerPatcher&currency_code=EUR
 ;y よくある質問 🡕
 ;https://github.com/valinet/ExplorerPatcher/wiki/Frequently-asked-questions
 ;y これらの設定の管理の詳細 🡕
 ;https://github.com/valinet/ExplorerPatcher/wiki/Settings-management
-;u 設定をインポートする
+;u 設定をインポート
 ;import
-;u 現在の設定をエクスポートする
+;u 現在の設定をエクスポート
 ;export
-;u 既定の設定に復元する
+;u デフォルトの設定を復元
 ;reset
 
 
 
 ;f
-;u ファイルエクスプローラーを再起動する (*)
+;u ファイル エクスプローラーを再起動 (*)
 ;restart
-;;u 既定の設定に復元する
+;;u デフォルトの設定を復元
 ;;reset
 ;;u ExplorerPatcher-jp について
 ;;about

--- a/ExplorerPatcher/settings10.reg
+++ b/ExplorerPatcher/settings10.reg
@@ -6,21 +6,21 @@ Windows Registry Editor Version 5.00
 
 ;T タスク バー
 [HKEY_CURRENT_USER\Software\ExplorerPatcher]
-;y 設定アプリにタスク バーオプションを追加する 🡕                                                       
+;y 設定アプリにタスク バー オプションを追加する 🡕                                                       
 ;ms-settings:taskbar
 ;y 通知領域のアイコンをカスタマイズする 🡕
 ;shell:::{05d7b0f4-2121-4eff-bf6b-ed3f69b894d9}
-;y 通知領域のアイコンをカスタマイズする 🡕
+;y 通知領域のシステム アイコンをカスタマイズする 🡕
 ;shell:::{05d7b0f4-2121-4eff-bf6b-ed3f69b894d9}\SystemIcons
 [HKEY_CURRENT_USER\Software\ExplorerPatcher]
 ;c 4 画面上のプライマリ タスク バーの位置 *
-;x 3 下 (既定)
+;x 3 下 (デフォルト)
 ;x 1 上
 ;x 0 左
 ;x 2 右
 ;"Virtualized_{D17F1E1A-5919-4427-8F89-A1A8503CA3EB}_TaskbarPosition"=dword:00000003
 ;c 4 画面上のセカンダリ タスク バーの位置
-;x 3 下 (既定)
+;x 3 下 (デフォルト)
 ;x 1 上
 ;x 0 左
 ;x 2 右
@@ -41,105 +41,105 @@ Windows Registry Editor Version 5.00
 ;b 自動でタスク バーを隠す
 ;"Virtualized_{D17F1E1A-5919-4427-8F89-A1A8503CA3EB}_AutoHideTaskbar"=dword:00000000
 [HKEY_CURRENT_USER\Software\ExplorerPatcher]
-;c 2 スタートボタンのスタイル *
-;x 0 Windows 10 (既定)
+;c 2 スタート ボタンのスタイル *
+;x 0 Windows 10 (デフォルト)
 ;x 1 Windows 11
 "OrbStyle"=dword:00000000
 ;c 5 プライマリ タスク バーの配置
-;x 0 画面端 (既定)
+;x 0 画面端 (デフォルト)
 ;x 1 中央
 ;x 5 中央、フルスクリーン時画面端
-;x 3 スタートボタンを中心に
-;x 7 スタートボタンを中心に、フルスクリーン時は画面端に配置
+;x 3 スタート ボタンを中心に
+;x 7 スタート ボタンを中心に、フルスクリーン時は画面端に配置
 "OldTaskbarAl"=dword:00000000
 ;c 5 プライマリ タスク バーの配置
-;x 0 画面端 (既定)
+;x 0 画面端 (デフォルト)
 ;x 1 中央
 ;x 5 中央、フルスクリーン時画面端
-;x 3 スタートボタンを中心に
-;x 7 スタートボタンを中心に、フルスクリーン時は画面端に配置
+;x 3 スタート ボタンを中心に
+;x 7 スタート ボタンを中心に、フルスクリーン時は画面端に配置
 "MMOldTaskbarAl"=dword:00000000
 [HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced]
 ;c 3 プライマリ タスク バーのアイコンを結合
 ;x 0 常に結合する
-;x 1 タスクバーがいっぱいのときに結合
-;x 2 結合しない (既定)
+;x 1 タスク バーがいっぱいのときに結合
+;x 2 結合しない (デフォルト)
 "TaskbarGlomLevel"=dword:00000000
 ;c 3 セカンダリ タスク バーのアイコン結合
 ;x 0 常に結合する
 ;x 1 タスク バーがいっぱいのときに結合
-;x 2 結合しない (既定)
+;x 2 結合しない (デフォルト)
 "MMTaskbarGlomLevel"=dword:00000000
-;c 2 タスク バーのアイコンサイズ
+;c 2 タスク バーのアイコン サイズ
 ;x 1 小さい
-;x 0 大きい (既定)
+;x 0 大きい (デフォルト)
 "TaskbarSmallIcons"=dword:00000000
 ;e 
 ;e 
 ;e 
 ;e 
 
-;T システムトレイ
+;T システム トレイ
 [HKEY_CURRENT_USER\Software\ExplorerPatcher]
-;b タスク バーとトレイのポップアップメニューのスキン
+;b タスク バーとトレイのポップアップ メニューのスキン
 "SkinMenus"=dword:00000001
-;b センタートレイのアイコンのポップアップメニュー
+;b センター トレイのアイコンのポップアップ メニュー
 "CenterMenus"=dword:00000001
-;b トレイアイコンのポップアップメニューのフライアウト動作
+;b トレイ アイコンのポップアップ メニューのフライアウト動作
 "FlyoutMenus"=dword:00000001
 [HKEY_CURRENT_USER\Software\Microsoft\TabletTip\1.7]
 ;b タッチ キーボード ボタンを表示する *
 "TipbandDesiredVisibility"=dword:00000000
 [HKEY_CURRENT_USER\Software\ExplorerPatcher]
 ;p 2
-;b Windows 11 スタイルのシステムアイコンを適用する *
+;b Windows 11 スタイルのシステム アイコンを適用する *
 "SkinIcons"=dword:00000001
 [HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced]
 ;b 時計に秒を表示する
 "ShowSecondsInSystemClock"=dword:00000000
 [HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced]
 ;c 3 デスクトップ ボタンを表示する
-;x 1 有効にする (既定)
+;x 1 有効にする (デフォルト)
 ;x 0 無効にする
 ;x 2 隠す
 "TaskbarSD"=dword:00000001
 [HKEY_CURRENT_USER\Software\ExplorerPatcher]
-;a ネットワークアイコンを右クリックし、「ネットワークとインターネットの設定を開く」
+;a ネットワーク アイコンを右クリックし、「ネットワークとインターネットの設定を開く」
 ;c 3 を選択した時開くウィンドウ
-;x 0 設定アプリのネットワーク設定 (既定)
-;x 1 コントロールパネルのネットワークと共有
-;x 2 コントロールパネルのネットワーク接続
+;x 0 設定アプリのネットワーク設定 (デフォルト)
+;x 1 コントロール パネルのネットワークと共有
+;x 2 コントロール パネルのネットワーク接続
 "ReplaceNetwork"=dword:00000000
 ;q
-;t システムトレイ上のアイコンをクリック時:
+;t システム トレイ上のアイコンをクリック時:
 [HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Control Panel\Settings\Network]
 ;c 5 ネットワーク
-;x 0 Windows 10 のフライアウト (既定)
+;x 0 Windows 10 のフライアウト (デフォルト)
 ;x 2 Windows 8 のフライアウト
 ;x 1 設定アプリのネットワーク設定
-;x 3 コントロールパネルのネットワークと共有
-;x 4 コントロールパネルのネットワーク接続
+;x 3 コントロール パネルのネットワークと共有
+;x 4 コントロール パネルのネットワーク接続
 "ReplaceVan"=dword:00000000
 [HKEY_CURRENT_USER\Software\Microsoft\Windows NT\CurrentVersion\MTCUVC]
 ;c 2 サウンド
-;x 1 Windows 10 のフライアウト (既定)
+;x 1 Windows 10 のフライアウト (デフォルト)
 ;x 0 Windows 7 のフライアウト
 "EnableMtcUvc"=dword:00000001
 [HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\ImmersiveShell]
 ;c 3 時計
-;x 0 Windows 10 のフライアウト (既定)
+;x 0 Windows 10 のフライアウト (デフォルト)
 ;x 1 Windows 7
-;x 2 アクションセンター
+;x 2 アクション センター
 "UseWin32TrayClockExperience"=dword:00000000
 [HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\ImmersiveShell]
 ;c 2 バッテリー
-;x 0 Windows 10 のフライアウト (既定)
+;x 0 Windows 10 のフライアウト (デフォルト)
 ;x 1 Windows 7
 "UseWin32BatteryFlyout"=dword:00000000
 
 
-;T ファイルエクスプローラー
-;e (**) の付いた設定が"ファイルを開く"または"ファイルを保存する"ダイアログで機能するには、
+;T ファイル エクスプローラー
+;e (**) の付いた設定が "ファイルを開く" または "ファイルを保存する" ダイアログで機能するには、
 ;e 以下のオプションを利用してこのプログラムをシェル拡張として登録します。
 ;y 詳しく見る 🡕
 ;https://github.com/valinet/ExplorerPatcher/wiki/Using-ExplorerPatcher-as-shell-extension
@@ -151,40 +151,40 @@ Windows Registry Editor Version 5.00
 ;b 常にレガシーなファイル転送ダイアログを使用する
 "LegacyFileTransferDialog"=dword:00000000
 [HKEY_CURRENT_USER\Software\ExplorerPatcher]
-;b クラシックなドライブグループを使用する
+;b クラシックなドライブ グループを使用する
 "UseClassicDriveGrouping"=dword:00000000
 [HKEY_CURRENT_USER\Software\ExplorerPatcher]
-;c 2 コントロールインターフェース
-;x 0 Windows 10 のリボン UI (既定)
-;x 2 Windows 7 のコマンドバー
+;c 2 コントロール インターフェイス
+;x 0 Windows 10 のリボン UI (デフォルト)
+;x 2 Windows 7 のコマンド バー
 "FileExplorerCommandUI"=dword:00000000
-;t 以下の設定は、新しく作成されたファイルエクスプローラーのウィンドウに適用されます:
+;t 以下の設定は、新しく作成されたファイル エクスプローラーのウィンドウに適用されます:
 [HKEY_CURRENT_USER\Software\ExplorerPatcher]
 ;i Windows 10 のコンテキストメニューの表示時、没入型メニューを使用する **
 "DisableImmersiveContextMenu"=dword:00000000
 [-HKEY_CURRENT_USER\Software\Classes\CLSID\{056440FD-8568-48e7-A632-72157243B55B}\InprocServer32]
-;d ナビゲーションバーを無効にする **
+;d ナビゲーション バーを無効にする **
 @=""
 [HKEY_CURRENT_USER\Software\ExplorerPatcher]
 ;b モダンな検索バーを無効にする
 ;"Virtualized_{D17F1E1A-5919-4427-8F89-A1A8503CA3EB}_DisableModernSearchBar"=dword:00000000
 [HKEY_CURRENT_USER\Software\ExplorerPatcher]
-;b アドレスバーの高さを下げる **
+;b アドレス バーの高さを下げる **
 "ShrinkExplorerAddressBar"=dword:00000000
 [HKEY_CURRENT_USER\Software\ExplorerPatcher]
 ;b 検索バーを完全に隠す **
 "HideExplorerSearchBar"=dword:00000000
 ;p 2
-;b マイカ効果タイトルバー
+;b マイカ効果タイトル バー
 "MicaEffectOnTitlebar"=dword:00000000
 
 
-;T スタートメニュー
-;y 設定アプリのその他のスタートメニューオプション 🡕
+;T スタート メニュー
+;y 設定アプリのその他のスタート メニュー オプション 🡕
 ;ms-settings:personalization-start
 [HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced]
 ;z 2 画面上の位置
-;x 0 画面端 (既定)
+;x 0 画面端 (デフォルト)
 ;x 1 中央
 "TaskbarAl"=dword:00000000
 [HKEY_CURRENT_USER\Software\ExplorerPatcher]
@@ -195,7 +195,7 @@ Windows Registry Editor Version 5.00
 ;x 3 3
 ;x 4 4
 ;x 5 5
-;x 6 6 (既定)
+;x 6 6 (デフォルト)
 ;x 7 7
 ;x 8 8
 ;x 9 9
@@ -213,9 +213,9 @@ Windows Registry Editor Version 5.00
 ;x 99999 無制限
 ;"Virtualized_{D17F1E1A-5919-4427-8F89-A1A8503CA3EB}_Start_MaximumFrequentApps"=dword:00000006
 [HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Explorer\StartPage]
-;e マルチ ディスプレイの場合、キーボードを使用すると設定されたディスプレイで
+;e マルチディスプレイの場合、キーボードを使用すると設定されたディスプレイで
 ;z 10 スタートが表示されます
-;x 1 プライマリ ディスプレイ (既定)
+;x 1 プライマリ ディスプレイ (デフォルト)
 ;x 0 カーソルがあるディスプレイ
 ;x 2 ディスプレイ #2
 ;x 3 ディスプレイ #3
@@ -228,32 +228,32 @@ Windows Registry Editor Version 5.00
 "MonitorOverride"=dword:00000001
 [HKEY_CURRENT_USER\Software\ExplorerPatcher]
 ;z 3 コーナーの設定
-;x 1 丸みを帯びた角、フローティングメニュー
-;x 2 丸みを帯びた角、ドッキングメニュー
+;x 1 丸みを帯びた角、フローティング メニュー
+;x 2 丸みを帯びた角、ドッキング メニュー
 ;x 0 丸みなし
 ;"Virtualized_{D17F1E1A-5919-4427-8F89-A1A8503CA3EB}_StartUI_EnableRoundedCorners"=dword:00000000
 [HKEY_CURRENT_USER\Software\ExplorerPatcher]
 ;z 3 表示方法
-;x 0 既定
-;x 1 スタートメニュー
-;x 2 フルスクリーンのスタートメニュー
+;x 0 デフォルト
+;x 1 スタート メニュー
+;x 2 フルスクリーンのスタート メニュー
 ;"Virtualized_{D17F1E1A-5919-4427-8F89-A1A8503CA3EB}_ForceStartSize"=dword:00000000
 ;z 3 アプリ一覧
 ;x 0 表示
 ;x 3 隠す
 ;x 1 無効にする 
 ;"Virtualized_{D17F1E1A-5919-4427-8F89-A1A8503CA3EB}_NoStartMenuMorePrograms"=dword:00000000
-;t 古いバージョンのWindows 10 では一部の設定が使用できない可能性があります。
+;t 古いバージョンの Windows 10 では一部の設定が使用できない可能性があります。
 
 
 ;T ウィンドウの切り替え
 [HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Explorer]
 ;z 3 ウィンドウの切り替え (Alt+Tab) のスタイルを変更 *
-;x 0 Windows 10 (既定)
+;x 0 Windows 10 (デフォルト)
 ;x 1 Windows NT
 ;x 2 Simple Window Switcher
 "AltTabSettings"=dword:00000000
-;t 以下の設定はSimple Window Switcher のみ適用されます:
+;t 以下の設定は Simple Window Switcher のみ適用されます:
 [HKEY_CURRENT_USER\Software\ExplorerPatcher\sws]
 ;b デスクトップを含める
 "IncludeWallpaper"=dword:00000001
@@ -261,12 +261,12 @@ Windows Registry Editor Version 5.00
 "PrimaryOnly"=dword:00000000
 ;b 現在のディスプレイで表示されているウィンドウのみを表示する
 "PerMonitor"=dword:00000000
-;b 直近のウィンドウのみ表示 (アプリケーションスイッチャーごと)
+;b 直近のウィンドウのみ表示 (アプリケーション スイッチャーごと)
 "SwitcherIsPerApplication"=dword:00000000
 ;b %PLACEHOLDER_0001%
 "NoPerApplicationList"=dword:00000000
 ;c 2 テーマ
-;x 0 既定
+;x 0 デフォルト
 ;x 1 アクリル
 "Theme"=dword:00000000
 [HKEY_CURRENT_USER\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\MultitaskingView\AltTabViewHost]
@@ -274,7 +274,7 @@ Windows Registry Editor Version 5.00
 ;x 100 不透明
 ;x 98 98 %
 ;x 96 96 %
-;x 95 95 % (既定)
+;x 95 95 % (デフォルト)
 ;x 94 94 %
 ;x 92 92 %
 ;x 90 90 %
@@ -293,7 +293,7 @@ Windows Registry Editor Version 5.00
 "Grid_backgroundPercent"=dword:0000005F
 [HKEY_CURRENT_USER\Software\ExplorerPatcher\sws]
 ;c 3 配色
-;x 0 システムの設定に従う (既定)
+;x 0 システムの設定に従う (デフォルト)
 ;x 1 ライト
 ;x 2 ダーク
 "ColorScheme"=dword:00000000
@@ -309,7 +309,7 @@ Windows Registry Editor Version 5.00
 ;x 260 260 pt
 ;x 250 250 pt
 ;x 240 240 pt
-;x 230 230 pt (既定)
+;x 230 230 pt (デフォルト)
 ;x 220 220 pt
 ;x 210 210 pt
 ;x 200 200 pt
@@ -325,7 +325,7 @@ Windows Registry Editor Version 5.00
 ;x 95 95 %
 ;x 90 90 %
 ;x 85 85 %
-;x 80 80 % (既定)
+;x 80 80 % (デフォルト)
 ;x 75 75 %
 ;x 70 70 %
 ;x 65 65 %
@@ -337,7 +337,7 @@ Windows Registry Editor Version 5.00
 ;x 95 95 %
 ;x 90 90 %
 ;x 85 85 %
-;x 80 80 % (既定)
+;x 80 80 % (デフォルト)
 ;x 75 75 %
 ;x 70 70 %
 ;x 65 65 %
@@ -347,7 +347,7 @@ Windows Registry Editor Version 5.00
 ;c 11 ウィンドウの余白
 ;x 50 50 pt
 ;x 45 45 pt
-;x 40 40 pt (既定)
+;x 40 40 pt (デフォルト)
 ;x 35 30 pt
 ;x 30 30 pt
 ;x 25 25 pt
@@ -362,7 +362,7 @@ Windows Registry Editor Version 5.00
 ;x 25 25 ミリ秒
 ;x 50 50 ミリ秒
 ;x 75 75 ミリ秒
-;x 100 100 ミリ秒 (既定)
+;x 100 100 ミリ秒 (デフォルト)
 ;x 125 125 ミリ秒
 ;x 150 150 ミリ秒
 ;x 200 200 ミリ秒
@@ -370,15 +370,15 @@ Windows Registry Editor Version 5.00
 ;x 400 400 ミリ秒
 ;x 500 500 ミリ秒
 "ShowDelay"=dword:00000064
-;c 3 ホイールスクロールで選択項目を変更
-;x 0 しない (既定)
+;c 3 ホイール スクロールで選択項目を変更
+;x 0 しない (デフォルト)
 ;x 1 カーソルが選択項目上にある場合
 ;x 2 常に
 "ScrollWheelBehavior"=dword:00000000
 ;q
 ;y Simple Window Switcher についての詳細はこちら 🡕
 ;https://github.com/valinet/ExplorerPatcher/wiki/Simple-Window-Switcher
-;t 古いバージョンのWindows 10 では一部の設定が使用できない可能性があります。
+;t 古いバージョンの Windows 10 では一部の設定が使用できない可能性があります。
 
 
 ;T 天気
@@ -386,58 +386,58 @@ Windows Registry Editor Version 5.00
 ;b タスク バーに天気を表示する
 ;"Virtualized_{D17F1E1A-5919-4427-8F89-A1A8503CA3EB}_PeopleBand"=dword:00000000
 ;c 5 レイアウト
-;x 0 アイコンと概要 (既定)
+;x 0 アイコンと概要 (デフォルト)
 ;x 3 アイコンと温度
 ;x 1 アイコンのみ
 ;x 4 温度のみ
 ;x 5 温度と概要
 "WeatherViewMode"=dword:00000000
 ;c 3 ウィジェットのサイズ
-;x 0 自動 (内容に合わせて) (既定)
+;x 0 自動 (内容に合わせて) (デフォルト)
 ;x 2 自動 (内容に合わせて) しきい値あり
 ;x 1 固定
 "WeatherFixedSize"=dword:00000000
 ;c 2 ウィジェットの位置
-;x 0 右 / 下部 (既定)
+;x 0 右 / 下部 (デフォルト)
 ;x 1 左 / 上部
 "WeatherToLeft"=dword:00000000
 ;c 7 更新頻度
 ;x 60 毎分
 ;x 300 5 分ごと
 ;x 900 15 分ごと
-;x 1200 20 分ごと (既定)
+;x 1200 20 分ごと (デフォルト)
 ;x 1800 30 分ごと
 ;x 3600 毎時間おき
 ;x 7200 数時間おき
 "WeatherContentUpdateMode"=dword:000004B0
 ;c 2 温度単位
-;x 0 摂氏 (既定)
+;x 0 摂氏 (デフォルト)
 ;x 1 華氏
 "WeatherTemperatureUnit"=dword:00000000
 ;w 場所
-;都市または郵便番号を検索します。プログラムはGoogleで"/*あなたが入力した場所*/の天気"を検索します。規定値(現在地)は空白のままにしておきます。
-;現在地 (既定)
+;都市または郵便番号を検索します。プログラムは Google で "/*あなたが入力した場所*/の天気" を検索します。デフォルト値 (現在地) は空白のままにしておきます。
+;現在地 (デフォルト)
 "WeatherLocation"=""
 ;;;c 2 位置情報の精度
-;;;x 0 一般的 (IPアドレスに基づく) (既定)
+;;;x 0 一般的 (IP アドレスに基づく) (デフォルト)
 ;;;x 1 精密 (位置情報を使用します)
 ;;"WeatherLocationType"=dword:00000000
 ;w 言語
-;天気データを表示させたい言語のショートコードを入力します。("en", "ro", "de", "fr "など) デフォルト値 (Windows の言語)は空白にしてください。
-;システムの言語 (既定)
+;天気データを表示させたい言語のショート コードを入力します。("en", "ro", "de", "fr" など) デフォルト値 (Windows の言語) は空白にしてください。
+;システムの言語 (デフォルト)
 "WeatherLanguage"=""
 ;c 3 配色
-;x 0 システムの設定に従う (既定)
+;x 0 システムの設定に従う (デフォルト)
 ;x 1 ライト
 ;x 2 ダーク
 "WeatherTheme"=dword:00000000
-;c 2 アイコンパック
-;x 0 Microsoft (既定)
+;c 2 アイコン パック
+;x 0 Microsoft (デフォルト)
 ;x 1 Google
 "WeatherIconPack"=dword:00000000
 ;c 2 ウィジェットの内容を表示する
-;x 0 1 行で表示 (既定)
-;x 1 可能であれば2 行で表示
+;x 0 1 行で表示 (デフォルト)
+;x 1 可能であれば 2 行で表示
 "WeatherContentsMode"=dword:00000000
 ;c 17 拡大率
 ;x 25 25 %
@@ -447,7 +447,7 @@ Windows Registry Editor Version 5.00
 ;x 75 75 %
 ;x 80 80 %
 ;x 90 90 %
-;x 0 100 % (既定)
+;x 0 100 % (デフォルト)
 ;x 110 110 %
 ;x 125 125 %
 ;x 150 150 %
@@ -459,12 +459,12 @@ Windows Registry Editor Version 5.00
 ;x 500 500 %
 "WeatherZoomFactor"=dword:00000000
 ;q
-;y 天気予報タスクバーウィジェットについてもっと知る 🡕
+;y 天気予報タスク バー ウィジェットについてもっと知る 🡕
 ;https://github.com/valinet/ExplorerPatcher/wiki/Weather
 ;t %WEATHERLASTUPDATETEXT%
 ;u 天気予報を更新する
 ;update_weather
-;u 天気予報ウィジェットのローカルデータをクリアする
+;u 天気予報ウィジェットのローカル データをクリアする
 ;clear_data_weather
 
 
@@ -473,30 +473,30 @@ Windows Registry Editor Version 5.00
 [HKEY_CURRENT_USER\Software\ExplorerPatcher]
 ;b このウィンドウで最後に使用したセクションを記憶する
 "LastSectionInProperties"=dword:00000000
-;b Win+Cを押した時、Microsoft Teams の代わりに時計のフライアウトを開く *
+;b Win+C を押した時、Microsoft Teams の代わりに時計のフライアウトを開く *
 "ClockFlyoutOnWinC"=dword:00000000
-;b タスクバーのツールバーの間にセパレーターを表示する *
+;b タスク バーのツールバーの間にセパレーターを表示する *
 "ToolbarSeparators"=dword:00000000
 [HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced]
-;b Win+X メニューのPowerShell の代わりにコマンドプロンプトを開く *
+;b Win+X メニューの PowerShell の代わりにコマンド プロンプトを開く *
 "DontUsePowerShellOnWinX"=dword:00000000
 [HKEY_CURRENT_USER\Software\ExplorerPatcher]
-;b Win+X メニューのプログラム設定項目からショートカットキーを削除する
+;b Win+X メニューのプログラム設定項目からショートカット キーを削除する
 "NoMenuAccelerator"=dword:00000000
-;b Office ホットキー (Ctrl+Alt+Shift+Windows キーの組み合わせ)を無効化する *
+;b Office ホットキー (Ctrl+Alt+Shift+Windows キーの組み合わせ) を無効化する *
 "DisableOfficeHotkeys"=dword:00000000
-;b Win+F (フィードバック Hub)ホットキーを無効化する *
+;b Win+F (フィードバック Hub) ホットキーを無効化する *
 "DisableWinFHotkey"=dword:00000000
 [HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced]
-;c 6 デスクトップ上のAlt+F4 ダイアログの既定の動作
+;c 6 デスクトップ上の Alt+F4 ダイアログのデフォルトの動作
 ;x 256 ユーザーの切り替え
 ;x 1 サインアウト
 ;x 16 スリープ
 ;x 64 休止状態
-;x 2 シャットダウン (既定)
+;x 2 シャットダウン (デフォルト)
 ;x 4 再起動
 "Start_PowerButtonAction"=dword:00000002
-;t 以下のコントロールパネルのリンクが設定アプリにリダイレクトされないようにします:
+;t 以下のコントロール パネルのリンクが設定アプリにリダイレクトされないようにします:
 [HKEY_CURRENT_USER\Software\ExplorerPatcher]
 ;b システム / このページについて
 "DoNotRedirectSystemToSettingsApp"=dword:00000000
@@ -510,8 +510,8 @@ Windows Registry Editor Version 5.00
 
 ;T アップデート
 [HKEY_CURRENT_USER\Software\ExplorerPatcher]
-;z 3 ファイルエクスプローラーの起動時
-;x 1 利用可能なアップデートを通知する (既定)
+;z 3 ファイル エクスプローラーの起動時
+;x 1 利用可能なアップデートを通知する (デフォルト)
 ;x 0 利用可能なアップデートをインストールするためのプロンプトを表示
 ;x 2 アップデートをチェックしない
 "UpdatePolicy"=dword:00000001
@@ -519,20 +519,20 @@ Windows Registry Editor Version 5.00
 "UpdatePreferStaging"=dword:00000000
 ;b 古いバージョンでも、サーバー上の最新バージョンを提案する (非推奨)
 "UpdateAllowDowngrades"=dword:00000000
-;t アップデートサーバー:
+;t アップデート サーバー:
 ;w リリース
-;GitHub の releases API に準拠したリソースを提供する URL を指定します。独自のアップデートサーバーを設定する方法については、wiki をご参照ください。
+;GitHub の releases API に準拠したリソースを提供する URL を指定します。独自のアップデート サーバーを設定する方法については、wiki をご参照ください。
 ;github.com/creeper-0910/ExplorerPatcher-jp/releases/latest
 "UpdateURL"=""
 ;w プレリリース
-;GitHub の releases API に準拠したリソースを提供する URL を指定します。独自のアップデートサーバーを設定する方法については、wiki をご参照ください。
+;GitHub の releases API に準拠したリソースを提供する URL を指定します。独自のアップデート サーバーを設定する方法については、wiki をご参照ください。
 ;api.github.com/repos/creeper-0910/ExplorerPatcher-jp/releases?per_page=1
 "UpdateURLStaging"=""
 ;y Check for updates
 ;;;EP_CHECK_FOR_UPDATES
-;y アップデートを確認する
+;y アップデートを確認
 ;;;EP_CHECK_FOR_UPDATES
-;y アップデートを行い、ファイルエクスプローラーを再起動する
+;y アップデートを行い、ファイル エクスプローラーを再起動
 ;;;EP_INSTALL_UPDATES
 ;y 最新リリースの変更点について 🡕
 ;https://github.com/valinet/ExplorerPatcher/blob/master/CHANGELOG.md
@@ -548,27 +548,27 @@ Windows Registry Editor Version 5.00
 [HKEY_CURRENT_USER\Software\ExplorerPatcher]
 ;b コンソールを有効にする
 "AllocConsole"=dword:00000000
-;b メモリリークをダンプする
+;b メモリ リークをダンプする
 "Memcheck"=dword:00000000
-;b タスク バーをダブルクリックで自動的に非表示にする (タスク バーが固定されている時のみ)
+;b タスク バーのダブルクリックで自動的に非表示にする (タスク バーが固定されている時のみ)
 "TaskbarAutohideOnDoubleClick"=dword:00000000
 [HKEY_CURRENT_USER\Control Panel\Desktop]
 ;b Windows のビルド情報をデスクトップに表示 *
 "PaintDesktopVersion"=dword:00000000
 [HKEY_CURRENT_USER\Software\ExplorerPatcher]
-;b クラシックテーマを使用した正しいレンダリングのための高度な緩和策を有効にする *
+;b クラシック テーマを使用した正しいレンダリングのための高度な緩和策を有効にする *
 "ClassicThemeMitigations"=dword:00000000
 [-HKEY_CURRENT_USER\Software\Classes\CLSID\{1eeb5b5a-06fb-4732-96b3-975c0194eb39}\InprocServer32]
-;d エクスプローラーのビューでSysListView32 を有効にする *
+;d エクスプローラーのビューで SysListView32 を有効にする *
 @=""
 [HKEY_CURRENT_USER\Software\ExplorerPatcher]
-;b タスク バーのコンテキストメニューを変更しない（例："プロパティ"項目を非表示にする）
+;b タスク バーのコンテキストメニューを変更しない（例: "プロパティ" 項目を非表示にする）
 "NoPropertiesInContextMenu"=dword:00000000
 ;b シンボルのダウンロードを有効化する *
 "EnableSymbolDownload"=dword:00000001
-;b ピン留めされたアイテムはクイック起動として機能します(ピン留めされたアイテムをアクティブなアプリと一緒にしないでください) *
+;b ピン留めされたアイテムはクイック起動として機能します (ピン留めされたアイテムをアクティブなアプリと一緒にしないでください) *
 "PinnedItemsActAsQuickLaunch"=dword:00000000
-;b タスクバーにボタンラベルが表示されている場合、ピン留めされているアイテムの周りの余分な隙間を削除する *
+;b タスク バーにボタン ラベルが表示されている場合、ピン留めされているアイテムの周りの余分な隙間を削除する *
 "RemoveExtraGapAroundPinnedItems"=dword:00000000
 
 
@@ -581,34 +581,34 @@ Windows Registry Editor Version 5.00
 ;e Valentin-Gabriel Radu によって設計されました。この非公式日本語版は、creeper-0910 によって作成されています。
 ;e 動作環境: Windows 11
 ;t OS ビルド: %OSVERSIONSTRING%
-;y プロジェクトのGitHub (公式ビルド) (https://github.com/valinet) 🡕
+;y プロジェクトの GitHub (公式ビルド) (https://github.com/valinet) 🡕
 ;https://github.com/valinet
 ;y プロジェクトのGitHub (非公式日本語版ビルド) (https://github.com/creeper-0910/ExplorerPatcher-jp) 🡕
 ;https://github.com/creeper-0910/ExplorerPatcher-jp
 ;q
-;y 公式のWeb サイト (https://www.valinet.ro) 🡕
+;y 公式の Webサイト (https://www.valinet.ro) 🡕
 ;https://www.valinet.ro
 ;y 公式の作者にメールを送る (valentingabrielradu@gmail.com) 🡕
 ;mailto:valentingabrielradu@gmail.com
-;y 公式の作者に寄付をする (PayPal を利用します) 🡕
+;y 公式の作者に寄付をする (PayPal を利用) 🡕
 ;https://www.paypal.com/donate?business=valentingabrielradu%40gmail.com&no_recurring=0&item_name=ExplorerPatcher&currency_code=EUR
 ;y よくある質問 🡕
 ;https://github.com/valinet/ExplorerPatcher/wiki/Frequently-asked-questions
 ;y これらの設定の管理の詳細 🡕
 ;https://github.com/valinet/ExplorerPatcher/wiki/Settings-management
-;u 設定をインポートする
+;u 設定をインポート
 ;import
-;u 現在の設定をエクスポートする
+;u 現在の設定をエクスポート
 ;export
-;u 既定の設定に復元する
+;u デフォルトの設定を復元
 ;reset
 
 
 
 ;f
-;u ファイルエクスプローラーを再起動する (*)
+;u ファイル エクスプローラーを再起動 (*)
 ;restart
-;;u 既定の設定に復元する
+;;u デフォルトの設定を復元
 ;;reset
 ;;u ExplorerPatcher-jp について
 ;;about

--- a/ExplorerPatcher/updates.c
+++ b/ExplorerPatcher/updates.c
@@ -199,7 +199,7 @@ BOOL IsUpdateAvailableHelper(
                 ) && dwRead == DOSMODE_OFFSET + UPDATES_HASH_SIZE)
                 {
 #ifdef UPDATES_VERBOSE_OUTPUT
-                    printf("[更新] リモートファイルのハッシュは \"%s\" (%s)です。\n", DOSMODE_OFFSET + hash, (hash[0] == 0x4D && hash[1] == 0x5A) ? "valid" : "invalid");
+                    printf("[更新] リモート ファイルのハッシュは \"%s\" (%s)です。\n", DOSMODE_OFFSET + hash, (hash[0] == 0x4D && hash[1] == 0x5A) ? "valid" : "invalid");
 #endif
                     BOOL bOldType = TRUE;
                     char *szLeftMost = NULL, *szSecondLeft = NULL, *szSecondRight = NULL, *szRightMost = NULL, *szRealHash = NULL;
@@ -545,7 +545,7 @@ BOOL IsUpdateAvailableHelper(
                                 );
 
                                 WCHAR wszMsg[500];
-                                swprintf_s(wszMsg, 500, L"" _T(PRODUCT_NAME) L"のアップデートをインストールしますか？\n\nダウンロード元:\n%s", wszURL2);
+                                swprintf_s(wszMsg, 500, L"" _T(PRODUCT_NAME) L"のアップデートをインストールしますか?\n\nダウンロード元:\n%s", wszURL2);
                                 if (MessageBoxW(
                                     FindWindowW(L"ExplorerPatcher_GUI_" _T(EP_CLSID), NULL),
                                     wszMsg,
@@ -576,7 +576,7 @@ BOOL IsUpdateAvailableHelper(
                                 {
                                     bIsUpdateAvailable = TRUE;
 #ifdef UPDATES_VERBOSE_OUTPUT
-                                    printf("[更新] アップデートに成功後、Explorerが再起動します。\n");
+                                    printf("[更新] アップデートに成功後、エクスプローラー が再起動します。\n");
 #endif
                                 }
                                 else
@@ -732,7 +732,7 @@ BOOL IsUpdateAvailable(LPCWSTR wszDataStore, char* szCheckAgainst, BOOL* lpFail,
         RegCloseKey(hKey);
     }
 #ifdef UPDATES_VERBOSE_OUTPUT
-    printf("[更新] 更新URL: %s\n", szUpdateURL);
+    printf("[更新] 更新 URL: %s\n", szUpdateURL);
 #endif
     return IsUpdateAvailableHelper(
         szUpdateURL, 
@@ -838,7 +838,7 @@ BOOL UpdateProduct(
         RegCloseKey(hKey);
     }
 #ifdef UPDATES_VERBOSE_OUTPUT
-    printf("[更新] 更新URL: %s\n", szUpdateURL);
+    printf("[更新] 更新 URL: %s\n", szUpdateURL);
 #endif
     return IsUpdateAvailableHelper(
         szUpdateURL, 
@@ -942,12 +942,12 @@ BOOL InstallUpdatesIfAvailable(
         case UPDATE_POLICY_AUTO:
         {
             dwUpdatePolicy = UPDATE_POLICY_AUTO;
-            printf("[更新] このシステムで設定されたアップデートポリシー: \"アップデートの自動インストール\"。\n");
+            printf("[更新] このシステムで設定されたアップデート ポリシー: \"アップデートの自動インストール\"。\n");
             break;
         }
         case UPDATE_POLICY_NOTIFY:
         {
-            printf("[更新] このシステムで設定されたアップデートポリシー: \"アップデートを確認し、ダウンロードとインストールを選択\"。\n");
+            printf("[更新] このシステムで設定されたアップデート ポリシー: \"アップデートを確認し、ダウンロードとインストールを選択\"。\n");
             break;
         }
         case UPDATE_POLICY_MANUAL:
@@ -1103,7 +1103,7 @@ BOOL InstallUpdatesIfAvailable(
                 L"	<visual>\r\n"
                 L"		<binding template=\"ToastGeneric\">\r\n"
                 L"			<text><![CDATA[%s が利用可能です。]]></text>\r\n"
-                L"			<text><![CDATA[アップデートをするには、タスクバーを右クリックして \"プロパティ\"、\"アップデート\"の順に選択してください。このアップデートについて詳しくは、こちらをご覧ください。]]></text>\r\n"
+                L"			<text><![CDATA[アップデートをするには、タスク バーを右クリックして \"プロパティ\"、\"アップデート\"の順に選択してください。このアップデートについて詳しくは、こちらをご覧ください。]]></text>\r\n"
                 L"			<text placement=\"attribution\"><![CDATA[ExplorerPatcher-jp]]></text>\r\n"
                 L"		</binding>\r\n"
                 L"	</visual>\r\n"
@@ -1155,7 +1155,7 @@ BOOL InstallUpdatesIfAvailable(
     {
         if (bFail)
         {
-            printf("[更新] リモートサーバーが利用できないため、アップデートを確認できません。\n");
+            printf("[更新] リモート サーバーが利用できないため、アップデートを確認できません。\n");
         }
         else
         {
@@ -1181,7 +1181,7 @@ BOOL InstallUpdatesIfAvailable(
                 L"	<visual>\r\n"
                 L"		<binding template=\"ToastGeneric\">\r\n"
                 L"			<text><![CDATA[アップデートの確認が出来ませんでした]]></text>\r\n"
-                L"			<text><![CDATA[インターネットに接続されていること、リモートサーバーがオンラインであることを確認してください。]]></text>\r\n"
+                L"			<text><![CDATA[インターネットに接続されていること、リモート サーバーがオンラインであることを確認してください。]]></text>\r\n"
                 L"			<text placement=\"attribution\"><![CDATA[ExplorerPatcher-jp]]></text>\r\n"
                 L"		</binding>\r\n"
                 L"	</visual>\r\n"


### PR DESCRIPTION
はじめまして。
本PRでは以下の修正対応を行っております。

-カタカナ語や英数字周りのスペーシングの修正
UI上で、例えば「アイコンサイズ」は「アイコン サイズ」とするのが正しいです
語句によっては例外もあるため、個別の修正に対する細かな理屈・説明は省きます。
基本的にマイクロソフトのスタイルガイドに準じる修正となります。

-「既定」と「デフォルト」の混同を再修正
「既定」は「原則変更不可な事柄」に対して用いる言葉です。変更可能な事柄において、Default は「初期値」としての意味合いが強くなります。
このため、一旦は「既定」に直された翻訳を「デフォルト」を戻すのが適切であると判断します。
「それを言うなら"初期値"にすべきでは?」との問いも想定されますが、「デフォルト」に代表されるカタカナ語の便利な逃げの一手は、ローカライズにおける常套手段として定着していると私は認識しております。
カタカナ語を多用しすぎると「翻訳されてない感」がにじみ出るため、特定の語句に絞ったり、頻度の限られる手法です。

困ったことにマイクロソフト自身 (または関連する翻訳者) が「既定/デフォルト」を混用してしまっており、ユーザーが語句の正しい使い分けを理解できずに混同してしまっていることが、翻訳界隈ではよく見られます。

-"ボタン" としての動作を意図した部分は「～する」を基本的につけない
下線のついた「設定をインポートする」→「設定をインポート」あたりを修正しています。
「〇〇を〇〇」と表記を揃えるため、以前に行われた変更から戻す修正も含まれます。

その他、全角記号を無為に用いないようにするなど、細かな修正が含まれます。

問題なさそうでしたらマージしていただけると幸いです。